### PR TITLE
[Refactor] Booking DTO 정보 구조화 - closes #6

### DIFF
--- a/src/main/java/com/nhnacademy/bookingservice/common/adaptor/MemberAdaptor.java
+++ b/src/main/java/com/nhnacademy/bookingservice/common/adaptor/MemberAdaptor.java
@@ -14,10 +14,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 public interface MemberAdaptor {
 
     @GetMapping("/email/{email}/info")
-    MemberResponse getMember(@PathVariable("email") String email);
+    MemberResponse getMemberByEmail(@PathVariable("email") String email);
 
     @GetMapping("/{no}/info")
-    MemberResponse getMember(@PathVariable("no") Long no);
+    MemberResponse getMemberByMbNo(@PathVariable("no") Long no);
 
     @PostMapping("/{mbNo}/password")
     Boolean verify(

--- a/src/main/java/com/nhnacademy/bookingservice/common/event/BookingEmailEventListener.java
+++ b/src/main/java/com/nhnacademy/bookingservice/common/event/BookingEmailEventListener.java
@@ -27,8 +27,8 @@ public class BookingEmailEventListener {
 
         BookingResponse booking = bookingRepository.findByNo(event.getBookingNo()).orElseThrow(BookingNotFoundException::new);
 
-        MeetingRoomResponse room = getMeetingRoom(booking.getRoomNo());
-        booking.setRoomName(room.getMeetingRoomName());
+        MeetingRoomResponse room = getMeetingRoom(booking.getRoom().getNo());
+        booking.getRoom().setName(room.getMeetingRoomName());
 
         EmailRequest request = new EmailRequest(
                 event.getEmail(),
@@ -64,8 +64,8 @@ public class BookingEmailEventListener {
                         """.formatted(
                                 event.getEmail(),
                                 booking.getCode(),
-                                booking.getRoomName(),
-                                booking.getDate().toString().replace("T", " "))
+                                booking.getRoom().getName(),
+                                booking.getStartsAt().toString().replace("T", " "))
         );
 
         notifyAdaptor.sendHtmlEmail(request);
@@ -78,8 +78,8 @@ public class BookingEmailEventListener {
 
         BookingResponse booking = bookingRepository.findByNo(event.getBookingNo()).orElseThrow(BookingNotFoundException::new);
 
-        MeetingRoomResponse room = getMeetingRoom(booking.getRoomNo());
-        booking.setRoomName(room.getMeetingRoomName());
+        MeetingRoomResponse room = getMeetingRoom(booking.getRoom().getNo());
+        booking.getRoom().setName(room.getMeetingRoomName());
 
         EmailRequest request = new EmailRequest(
                 event.getEmail(),
@@ -106,8 +106,8 @@ public class BookingEmailEventListener {
                         """.formatted(
                         event.getEmail(),
                         booking.getCode(),
-                        booking.getRoomName(),
-                        booking.getDate().toString().replace("T", " "))
+                        booking.getRoom().getName(),
+                        booking.getStartsAt().toString().replace("T", " "))
         );
 
         notifyAdaptor.sendHtmlEmail(request);

--- a/src/main/java/com/nhnacademy/bookingservice/controller/BookingController.java
+++ b/src/main/java/com/nhnacademy/bookingservice/controller/BookingController.java
@@ -45,7 +45,7 @@ public class BookingController {
      */
     @ModelAttribute("memberInfo")
     public MemberResponse getMemberInfo(@RequestHeader("X-USER") String email){
-        return  memberAdaptor.getMember(email);
+        return  memberAdaptor.getMemberByEmail(email);
     }
 
     /**

--- a/src/main/java/com/nhnacademy/bookingservice/dto/BookingResponse.java
+++ b/src/main/java/com/nhnacademy/bookingservice/dto/BookingResponse.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode
+@SuppressWarnings("java:S107")
 public class BookingResponse {
 
     private Long no;
@@ -16,7 +17,7 @@ public class BookingResponse {
     private String code;
 
     @EqualsAndHashCode.Exclude
-    private LocalDateTime date;
+    private LocalDateTime startsAt;
 
     private Integer attendeeCount;
 
@@ -26,31 +27,44 @@ public class BookingResponse {
     @EqualsAndHashCode.Exclude
     private LocalDateTime createdAt;
 
-    private Long mbNo;
-
-    @Setter
-    private String mbName;
-
-    @Setter
-    private String email;
-
     private String changeName;
 
-    private Long roomNo;
+    private MemberInfo member;
 
+    private MeetingRoomInfo room;
+
+    @Getter
     @Setter
-    private String roomName;
+    public static class MemberInfo {
+        private Long no;
+
+        private String name;
+
+        private String email;
+    }
+
+    @Getter
+    @Setter
+    public static class MeetingRoomInfo {
+        private Long no;
+
+        private String name;
+    }
 
     @QueryProjection
-    public BookingResponse(Long no, String code, LocalDateTime date, Integer attendeeCount, LocalDateTime finishesAt, LocalDateTime createdAt, Long mbNo, String changeName, Long roomNo) {
+    public BookingResponse(Long no, String code, LocalDateTime startsAt, Integer attendeeCount, LocalDateTime finishesAt, LocalDateTime createdAt, String changeName, Long mbNo, Long roomNo) {
         this.no = no;
         this.code = code;
-        this.date = date;
+        this.startsAt = startsAt;
         this.attendeeCount = attendeeCount;
         this.finishesAt = finishesAt;
         this.createdAt = createdAt;
-        this.mbNo = mbNo;
         this.changeName = changeName;
-        this.roomNo = roomNo;
+
+        this.member = new MemberInfo();
+        this.member.setNo(mbNo);
+
+        this.room = new MeetingRoomInfo();
+        this.room.setNo(roomNo);
     }
 }

--- a/src/main/java/com/nhnacademy/bookingservice/repository/impl/CustomBookingRepositoryImpl.java
+++ b/src/main/java/com/nhnacademy/bookingservice/repository/impl/CustomBookingRepositoryImpl.java
@@ -12,7 +12,6 @@ import com.nhnacademy.bookingservice.repository.CustomBookingRepository;
 import com.nhnacademy.bookingservice.repository.util.QueryDslUtil;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -46,8 +45,8 @@ public class CustomBookingRepositoryImpl extends QuerydslRepositorySupport imple
                         qBooking.attendeeCount,
                         qBooking.finishesAt,
                         qBooking.createdAt,
-                        qBooking.mbNo,
                         qBooking.bookingChange.name.as("changeName"),
+                        qBooking.mbNo,
                         qBooking.roomNo
                 ))
                 .from(qBooking)

--- a/src/test/java/com/nhnacademy/bookingservice/common/event/BookingEmailEventListenerTest.java
+++ b/src/test/java/com/nhnacademy/bookingservice/common/event/BookingEmailEventListenerTest.java
@@ -6,6 +6,7 @@ import com.nhnacademy.bookingservice.dto.BookingResponse;
 import com.nhnacademy.bookingservice.dto.EmailRequest;
 import com.nhnacademy.bookingservice.dto.MeetingRoomResponse;
 import com.nhnacademy.bookingservice.repository.BookingRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,11 +36,25 @@ class BookingEmailEventListenerTest {
     @InjectMocks
     private BookingEmailEventListener listener;
 
+    BookingResponse.MemberInfo member;
+    BookingResponse.MeetingRoomInfo room;
+
+    @BeforeEach
+    void setUp(){
+        member = new BookingResponse.MemberInfo();
+        member.setNo(1L);
+        member.setEmail("test@test.com");
+        member.setName("test");
+
+        room = new BookingResponse.MeetingRoomInfo();
+        room.setNo(1L);
+        room.setName("회의실 A");
+    }
 
     @Test
     @DisplayName("이메일 발송 - 예약 생성")
     void handleBookingCreatedEvent() {
-        BookingResponse bookingResponse = new BookingResponse(1L, "test", LocalDateTime.parse("2025-04-29T09:30:00"), 8, LocalDateTime.parse("2025-04-29T08:30:00"), LocalDateTime.parse("2025-04-29T09:30:00"), 1L, "test", null,null, 1L, "회의실 A");
+        BookingResponse bookingResponse = new BookingResponse(1L, "test", LocalDateTime.parse("2025-04-29T09:30:00"), 8, LocalDateTime.parse("2025-04-29T08:30:00"), LocalDateTime.parse("2025-04-29T09:30:00"), null, member, room);
         MeetingRoomResponse roomResponse = new MeetingRoomResponse(1L, "회의실 A", 6);
 
         String email = "test@example.com";
@@ -57,7 +72,7 @@ class BookingEmailEventListenerTest {
     @Test
     @DisplayName("이메일 발송 - 예약 취소")
     void handleBookingCancelEvent() {
-        BookingResponse bookingResponse = new BookingResponse(1L, "test", LocalDateTime.parse("2025-04-29T09:30:00"), 8, LocalDateTime.parse("2025-04-29T08:30:00"), LocalDateTime.parse("2025-04-29T09:30:00"), 1L, "test", null,null, 1L, "회의실 A");
+        BookingResponse bookingResponse = new BookingResponse(1L, "test", LocalDateTime.parse("2025-04-29T09:30:00"), 8, LocalDateTime.parse("2025-04-29T08:30:00"), LocalDateTime.parse("2025-04-29T09:30:00"),null, member, room);
         MeetingRoomResponse roomResponse = new MeetingRoomResponse(1L, "회의실 A", 6);
 
         String email = "test@example.com";

--- a/src/test/java/com/nhnacademy/bookingservice/repository/impl/BookingRepositoryImplTest.java
+++ b/src/test/java/com/nhnacademy/bookingservice/repository/impl/BookingRepositoryImplTest.java
@@ -21,6 +21,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -79,8 +80,8 @@ class BookingRepositoryImplTest {
         assertAll(() -> {
             assertEquals("test1", response.getCode());
             assertNull(response.getChangeName());
-            assertEquals(1L, response.getMbNo());
-            assertEquals(1L, response.getRoomNo());
+            assertEquals(1L, response.getMember().getNo());
+            assertEquals(1L, response.getRoom().getNo());
         });
     }
 
@@ -101,8 +102,8 @@ class BookingRepositoryImplTest {
             assertEquals(1, response.size());
             assertEquals("test2", response.getFirst().getCode());
             assertEquals(8, response.getFirst().getAttendeeCount());
-            assertEquals(1L, response.getFirst().getMbNo());
-            assertEquals(2L, response.getFirst().getRoomNo());
+            assertEquals(1L, response.getFirst().getMember().getNo());
+            assertEquals(2L, response.getFirst().getRoom().getNo());
         });
     }
 
@@ -124,13 +125,13 @@ class BookingRepositoryImplTest {
 
             assertEquals("test3", response.get(1).getCode());
             assertEquals(9, response.get(1).getAttendeeCount());
-            assertEquals(2L, response.get(1).getMbNo());
-            assertEquals(2L, response.get(1).getRoomNo());
+            assertEquals(2L, response.get(1).getMember().getNo());
+            assertEquals(2L, response.get(1).getRoom().getNo());
 
             assertEquals("test2", response.getFirst().getCode());
             assertEquals(8, response.getFirst().getAttendeeCount());
-            assertEquals(1L, response.getFirst().getMbNo());
-            assertEquals(2L, response.getFirst().getRoomNo());
+            assertEquals(1L, response.getFirst().getMember().getNo());
+            assertEquals(2L, response.getFirst().getRoom().getNo());
         });
     }
 
@@ -140,12 +141,23 @@ class BookingRepositoryImplTest {
         Booking booking = Booking.ofNewBooking("test2", LocalDateTime.parse("2025-04-29T09:30:00"), 8, LocalDateTime.parse("2025-04-29T10:30:00"), 1L, null, 2L);
         manager.persistAndFlush(booking);
 
-        BookingResponse bookingResponse = new BookingResponse(booking.getBookingNo(), booking.getBookingCode(), booking.getBookingDate(), booking.getAttendeeCount(), booking.getFinishesAt(), booking.getCreatedAt(), booking.getMbNo(),  null, booking.getRoomNo());
+        BookingResponse.MemberInfo member = new BookingResponse.MemberInfo();
+        member.setNo(1L);
+        BookingResponse.MeetingRoomInfo room = new BookingResponse.MeetingRoomInfo();
+        room.setNo(2L);
+
+        BookingResponse bookingResponse = new BookingResponse(booking.getBookingNo(), booking.getBookingCode(), booking.getBookingDate(), booking.getAttendeeCount(), booking.getFinishesAt(), booking.getCreatedAt(),  null, member, room);
 
         Page<BookingResponse> response = bookingRepository.findBookings(1L, Pageable.ofSize(1));
 
-        assertNotNull(response);
-        assertTrue(response.getContent().contains(bookingResponse));
+        BookingResponse actual = response.getContent().getFirst();
+
+        assertAll(() -> {
+            assertEquals(bookingResponse.getNo(), actual.getNo());
+            assertEquals(bookingResponse.getCode(), actual.getCode());
+            assertEquals(bookingResponse.getMember().getNo(), actual.getMember().getNo());
+            assertEquals(bookingResponse.getRoom().getNo(), actual.getRoom().getNo());
+        });
     }
 
     @Test
@@ -174,8 +186,8 @@ class BookingRepositoryImplTest {
         assertNotNull(bookingResponse);
         assertAll(() -> {
             assertEquals("test4", bookingResponse.getCode());
-            assertEquals(1L, bookingResponse.getMbNo());
-            assertEquals(2L, bookingResponse.getRoomNo());
+            assertEquals(1L, bookingResponse.getMember().getNo());
+            assertEquals(2L, bookingResponse.getRoom().getNo());
         });
     }
 
@@ -207,8 +219,8 @@ class BookingRepositoryImplTest {
         assertNotNull(bookingResponse);
         assertAll(() -> {
             assertEquals("test2", bookingResponse.getCode());
-            assertEquals(1L, bookingResponse.getMbNo());
-            assertEquals(2L, bookingResponse.getRoomNo());
+            assertEquals(1L, bookingResponse.getMember().getNo());
+            assertEquals(2L, bookingResponse.getRoom().getNo());
         });
     }
 

--- a/src/test/java/com/nhnacademy/bookingservice/service/impl/BookingServiceImplTest.java
+++ b/src/test/java/com/nhnacademy/bookingservice/service/impl/BookingServiceImplTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -67,7 +68,16 @@ class BookingServiceImplTest {
         Booking booking = Booking.ofNewBooking("test", LocalDateTime.parse("2025-04-29T09:30:00"), 8, LocalDateTime.parse("2025-04-29T10:30:00"), 1L, null, 2L);
         ReflectionTestUtils.setField(booking, "bookingNo", 1L);
 
-        bookingResponse = new BookingResponse(booking.getBookingNo(), booking.getBookingCode(), booking.getBookingDate(), booking.getAttendeeCount(), booking.getFinishesAt(), booking.getCreatedAt(), booking.getMbNo(),  null, booking.getRoomNo());
+        BookingResponse.MemberInfo member = new BookingResponse.MemberInfo();
+        member.setNo(1L);
+        member.setEmail("test@test.com");
+        member.setName("test");
+
+        BookingResponse.MeetingRoomInfo room = new BookingResponse.MeetingRoomInfo();
+        room.setNo(1L);
+        room.setName("회의실 A");
+
+        bookingResponse = new BookingResponse(booking.getBookingNo(), booking.getBookingCode(), booking.getBookingDate(), booking.getAttendeeCount(), booking.getFinishesAt(), booking.getCreatedAt(), null, member, room);
 
     }
 
@@ -190,13 +200,13 @@ class BookingServiceImplTest {
     @DisplayName("예약 전체 조회 - 리스트")
     void getAllBookings_list() {
         when(bookingRepository.findBookingList(null)).thenReturn(List.of(bookingResponse));
-        when(memberAdaptor.getMember(Mockito.anyLong())).thenReturn(memberInfo);
+        when(memberAdaptor.getMemberByMbNo(Mockito.anyLong())).thenReturn(memberInfo);
         when(meetingRoomAdaptor.getMeetingRoom(Mockito.anyLong())).thenReturn(meetingRoomResponse);
 
         bookingService.getBookings();
-      
+
         Mockito.verify(bookingRepository, Mockito.atLeast(1)).findBookingList(null);
-        Mockito.verify(memberAdaptor, Mockito.atLeast(1)).getMember(Mockito.anyLong());
+        Mockito.verify(memberAdaptor, Mockito.atLeast(1)).getMemberByMbNo(Mockito.anyLong());
         Mockito.verify(meetingRoomAdaptor, Mockito.atLeast(1)).getMeetingRoom(Mockito.anyLong());
     }
 
@@ -216,13 +226,13 @@ class BookingServiceImplTest {
     @DisplayName("예약 전체 조회 - 페이징")
     void getAllBookings_page() {
         when(bookingRepository.findBookings(null, Pageable.ofSize(1))).thenReturn(new PageImpl<>(List.of(bookingResponse)));
-        when(memberAdaptor.getMember(Mockito.anyLong())).thenReturn(memberInfo);
+        when(memberAdaptor.getMemberByMbNo(Mockito.anyLong())).thenReturn(memberInfo);
         when(meetingRoomAdaptor.getMeetingRoom(Mockito.anyLong())).thenReturn(meetingRoomResponse);
 
         bookingService.getPagedBookings(Pageable.ofSize(1));
 
         Mockito.verify(bookingRepository, Mockito.atLeast(1)).findBookings(null, Pageable.ofSize(1));
-        Mockito.verify(memberAdaptor, Mockito.atLeast(1)).getMember(Mockito.anyLong());
+        Mockito.verify(memberAdaptor, Mockito.atLeast(1)).getMemberByMbNo(Mockito.anyLong());
         Mockito.verify(meetingRoomAdaptor, Mockito.atLeast(1)).getMeetingRoom(Mockito.anyLong());
     }
 
@@ -230,21 +240,21 @@ class BookingServiceImplTest {
     @DisplayName("예약 전체 조회 - memberNotFound")
     void getAllBookings_exception_case1() {
         when(bookingRepository.findBookings(null, Pageable.ofSize(1))).thenReturn(new PageImpl<>(List.of(bookingResponse)));
-        when(memberAdaptor.getMember(Mockito.anyLong())).thenThrow(NotFoundException.class);
+        when(memberAdaptor.getMemberByMbNo(Mockito.anyLong())).thenThrow(NotFoundException.class);
 
         Pageable pageable = Pageable.ofSize(1);
 
         Assertions.assertThrows(NotFoundException.class, () -> bookingService.getPagedBookings(pageable));
 
         Mockito.verify(bookingRepository, Mockito.atLeast(1)).findBookings(null, Pageable.ofSize(1));
-        Mockito.verify(memberAdaptor, Mockito.atLeast(1)).getMember(Mockito.anyLong());
+        Mockito.verify(memberAdaptor, Mockito.atLeast(1)).getMemberByMbNo(Mockito.anyLong());
     }
 
     @Test
     @DisplayName("예약 전체 조회 - meetingRoomNotFound")
     void getAllBookings_exception_case2() {
         when(bookingRepository.findBookings(null, Pageable.ofSize(1))).thenReturn(new PageImpl<>(List.of(bookingResponse)));
-        when(memberAdaptor.getMember(Mockito.anyLong())).thenReturn(memberInfo);
+        when(memberAdaptor.getMemberByMbNo(Mockito.anyLong())).thenReturn(memberInfo);
         when(meetingRoomAdaptor.getMeetingRoom(Mockito.anyLong())).thenThrow(NotFoundException.class);
 
         Pageable pageable = Pageable.ofSize(1);
@@ -252,7 +262,7 @@ class BookingServiceImplTest {
         Assertions.assertThrows(NotFoundException.class, () -> bookingService.getPagedBookings(pageable));
 
         Mockito.verify(bookingRepository, Mockito.atLeast(1)).findBookings(null, Pageable.ofSize(1));
-        Mockito.verify(memberAdaptor, Mockito.atLeast(1)).getMember(Mockito.anyLong());
+        Mockito.verify(memberAdaptor, Mockito.atLeast(1)).getMemberByMbNo(Mockito.anyLong());
         Mockito.verify(meetingRoomAdaptor, Mockito.atLeast(1)).getMeetingRoom(Mockito.anyLong());
     }
 
@@ -466,8 +476,8 @@ class BookingServiceImplTest {
                 attendeeCount,
                 finishesAt,
                 LocalDateTime.now(),
-                mbNo,
                 null,
+                mbNo,
                 roomNo
         );
 
@@ -499,8 +509,8 @@ class BookingServiceImplTest {
                 attendeeCount,
                 finishesAt,
                 LocalDateTime.now(),
-                mbNo,
                 null,
+                mbNo,
                 roomNo
         );
 
@@ -537,8 +547,8 @@ class BookingServiceImplTest {
                 attendeeCount,
                 finishesAt,
                 LocalDateTime.now(),
-                mbNo,
                 null,
+                mbNo,
                 roomNo
         );
 
@@ -572,8 +582,8 @@ class BookingServiceImplTest {
                 attendeeCount,
                 finishesAt,
                 LocalDateTime.now(),
-                mbNo,
                 null,
+                mbNo,
                 roomNo
         );
 
@@ -607,8 +617,8 @@ class BookingServiceImplTest {
                 attendeeCount,
                 finishesAt,
                 LocalDateTime.now(),
-                mbNo,
                 null,
+                mbNo,
                 roomNo
         );
 


### PR DESCRIPTION
## 📄 필독

- DTO 구조 리팩토링에 따라 Booking 응답 객체의 JSON 구조가 변경되었습니다.
- `member`, `room` 정보를 각각 내부 객체(`MemberInfo`, `MeetingRoomInfo`)로 분리하여 포함합니다.
- 프론트엔드에서 응답 파싱 방식 수정이 필요할 수 있습니다.

---

## 📌 관련 이슈

* Closes #6 

---

## 📝 작업 내용

* `BookingResponse` DTO 내 `MemberInfo`, `MeetingRoomInfo` 클래스를 중첩 구조로 정의
* QueryDSL에서 `mbNo`, `roomNo`만 주입 후 내부 객체 필드는 서비스 계층에서 외부 API로 주입
* 테스트 코드 수정 및 리팩토링 반영

---

## ✅ 변경 사항 요약

| 항목       | 변경 전                      | 변경 후                                |
|------------|-------------------------------|-----------------------------------------|
| 응답 구조  | flat 구조 (`mbNo`, `roomNo`) | 중첩 구조 (`member.no`, `room.no`)     |
| 데이터 주입 | 단순 필드 주입                | 내부 객체 생성 후 필드 주입             |

---

## ✅ 체크리스트

* [x] 관련 이슈 번호를 `Fixes`, `Closes`, `Resolves` 중 하나로 정확히 적었는가?
* [x] 기능/버그/요청사항과 연관된 작업이 맞는가?
* [x] 코드에 문법 오류는 없는가?
* [x] 기능이 정상 동작하는가?

---

## 💡 리뷰어 참고 사항

* 외부 시스템(MSA) 구조상 Member/Room은 Feign Client나 Gateway API로 추가 조회가 필요합니다.
* Projection으로는 no 값만 포함되고, 상세 필드는 서비스 단에서 주입합니다.

---

## 📦 테스트 방법

1. 예약 데이터를 저장 후 API 응답을 확인
2. 응답의 `member.no`, `room.no` 필드가 포함되는지 확인
3. 외부 API 또는 Mock 데이터를 통해 `member.name`, `room.name` 주입이 가능한지 검증
