### PR TITLE
[Feature] Front에서 입력된 예약코드 검증 

### DIFF
--- a/src/main/java/com/nhnacademy/bookingservice/common/exception/booking/BookingInfoDoesNotMatchException.java
+++ b/src/main/java/com/nhnacademy/bookingservice/common/exception/booking/BookingInfoDoesNotMatchException.java
@@ -1,9 +1,9 @@
 package com.nhnacademy.bookingservice.common.exception.booking;
 
-import com.nhnacademy.bookingservice.common.exception.BadRequestException;
+import com.nhnacademy.bookingservice.common.exception.NotFoundException;
 
 @SuppressWarnings("java:S110")
-public class BookingInfoDoesNotMatchException extends BadRequestException {
+public class BookingInfoDoesNotMatchException extends NotFoundException {
 
     public BookingInfoDoesNotMatchException() {
         super("예약정보가 일치하지 않습니다.");

--- a/src/main/java/com/nhnacademy/bookingservice/controller/BookingController.java
+++ b/src/main/java/com/nhnacademy/bookingservice/controller/BookingController.java
@@ -135,7 +135,7 @@ public class BookingController {
      * @return 해당 회의실의 일일 예약 목록
      */
     @GetMapping("/meeting-rooms/{roomNo}/date/{date}")
-    public ResponseEntity<List<DailyBookingResponse>> getDailyBookings(@PathVariable("roomNo")Long roomNo, @PathVariable("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+    public ResponseEntity<List<DailyBookingResponse>> getDailyBookings(@PathVariable("roomNo") Long roomNo, @PathVariable("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
         List<DailyBookingResponse> responses = bookingService.getDailyBookings(roomNo, date);
         return ResponseEntity.ok(responses);
     }
@@ -193,20 +193,19 @@ public class BookingController {
     /**
      * 회의실 사용 예약을 확인하고, 해당 회의실 예약 정보를 반환합니다.
      *
-     * @param no 예약번호
      * @param entryRequest 회의실 입실 요청 DTO
      * @return EntryResponse 회의실 입실 응답 ResponseEntity
      */
-    @PostMapping("/{no}/enter")
-    public ResponseEntity<EntryResponse> checkBooking(@PathVariable("no") Long no, @Validated @RequestBody EntryRequest entryRequest) {
-        boolean isPermitted = bookingService.checkBooking(no, entryRequest.getCode(), entryRequest.getEntryTime(), entryRequest.getMeetingRoomNo());
+    @PostMapping("/verify") // meeting-room-no가 아닌 booking-no로 설계해야 RESTful.
+    public ResponseEntity<EntryResponse> checkBooking(@Validated @RequestBody EntryRequest entryRequest) {
+        boolean isPermitted = bookingService.checkBooking(entryRequest.getCode(), entryRequest.getEntryTime(), entryRequest.getBookingNo());
 
         if (isPermitted) {
             return ResponseEntity
                     .ok(new EntryResponse(
                             entryRequest.getCode(),
                             entryRequest.getEntryTime(),
-                            entryRequest.getMeetingRoomNo()
+                            entryRequest.getBookingNo()
                     ));
         } else {
             return ResponseEntity

--- a/src/main/java/com/nhnacademy/bookingservice/dto/EntryRequest.java
+++ b/src/main/java/com/nhnacademy/bookingservice/dto/EntryRequest.java
@@ -18,5 +18,5 @@ public class EntryRequest {
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime entryTime;
 
-    private Long meetingRoomNo;
+    private Long bookingNo;
 }

--- a/src/main/java/com/nhnacademy/bookingservice/dto/EntryResponse.java
+++ b/src/main/java/com/nhnacademy/bookingservice/dto/EntryResponse.java
@@ -15,6 +15,6 @@ public class EntryResponse {
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime entryTime;
 
-    private Long meetingRoomNo;
+    private Long bookingNo;
 
 }

--- a/src/main/java/com/nhnacademy/bookingservice/service/BookingService.java
+++ b/src/main/java/com/nhnacademy/bookingservice/service/BookingService.java
@@ -111,7 +111,7 @@ public interface BookingService {
     void cancelBooking(Long no, MemberResponse memberInfo);
 
 
-    boolean checkBooking(Long no, String code, LocalDateTime entryTime, Long meetingRoomNo);
+    boolean checkBooking(String code, LocalDateTime entryTime, Long meetingRoomNo);
 
     /**
      * 본인 인증 합니다.

--- a/src/main/java/com/nhnacademy/bookingservice/service/impl/BookingServiceImpl.java
+++ b/src/main/java/com/nhnacademy/bookingservice/service/impl/BookingServiceImpl.java
@@ -253,16 +253,15 @@ public class BookingServiceImpl implements BookingService{
 
     /**
      *
-     * @param no 예약번호
      * @param code 회의실 예약 시 발급 받은 예약 코드
      * @param entryTime 회의실
-     * @param meetingRoomNo 회의실 번호
+     * @param bookingNo 예약번호
      * @return 회의실 입실 허가 boolean 반환
      */
     @Override
-    public boolean checkBooking(Long no, String code, LocalDateTime entryTime, Long meetingRoomNo) {
+    public boolean checkBooking(String code, LocalDateTime entryTime, Long bookingNo) {
         // 저장된 예약정보 찾아오기
-        BookingResponse bookingResponse = bookingRepository.findByNo(no).orElseThrow(() -> new BookingNotFoundException(no));
+        BookingResponse bookingResponse = bookingRepository.findByNo(bookingNo).orElseThrow(() -> new BookingNotFoundException(bookingNo));
 
         // 저장된 예약정보 내 예약코드
         String bookingCode = bookingResponse.getCode();

--- a/src/test/java/com/nhnacademy/bookingservice/service/impl/BookingServiceImplTest.java
+++ b/src/test/java/com/nhnacademy/bookingservice/service/impl/BookingServiceImplTest.java
@@ -155,7 +155,7 @@ class BookingServiceImplTest {
 
         when(bookingRepository.findByNo(Mockito.anyLong())).thenReturn(Optional.of(bookingResponse));
 
-        assertThrows(ForbiddenException.class, () -> bookingService.getBooking(1L, member));
+        Assertions.assertThrows(ForbiddenException.class, () -> bookingService.getBooking(1L, member));
 
         Mockito.verify(bookingRepository, Mockito.times(1)).findByNo(Mockito.anyLong());
     }
@@ -167,7 +167,7 @@ class BookingServiceImplTest {
 
         when(bookingRepository.findByNo(Mockito.anyLong())).thenReturn(Optional.empty());
 
-        assertThrows(BookingNotFoundException.class, () -> bookingService.getBooking(1L, member));
+        Assertions.assertThrows(BookingNotFoundException.class, () -> bookingService.getBooking(1L, member));
 
         Mockito.verify(bookingRepository, Mockito.times(1)).findByNo(Mockito.anyLong());
     }
@@ -484,10 +484,10 @@ class BookingServiceImplTest {
         when(bookingRepository.findByNo(Mockito.anyLong())).thenReturn(Optional.of(response));
 
         // when
-        boolean result = bookingService.checkBooking(no, code, LocalDateTime.parse("2025-04-29T09:20:00"), roomNo);
+        boolean result = bookingService.checkBooking(code, LocalDateTime.parse("2025-04-29T09:20:00"), roomNo);
 
         // then
-        assertTrue(result);
+        Assertions.assertTrue(result);
     }
 
     @Test
@@ -523,8 +523,8 @@ class BookingServiceImplTest {
         LocalDateTime entryTime = date.minusMinutes(5);
 
         // then
-        assertThrows(BookingInfoDoesNotMatchException.class, () ->
-                bookingService.checkBooking(1L, wrongCode, entryTime, roomNo)
+        Assertions.assertThrows(BookingInfoDoesNotMatchException.class, () ->
+                bookingService.checkBooking(wrongCode, entryTime, roomNo)
         );
     }
 
@@ -558,8 +558,8 @@ class BookingServiceImplTest {
         LocalDateTime differentDateEntry = LocalDateTime.parse("2025-04-30T09:30:00");
 
         // then
-        assertThrows(BookingInfoDoesNotMatchException.class, () ->
-                bookingService.checkBooking(no, code, differentDateEntry, roomNo)
+        Assertions.assertThrows(BookingInfoDoesNotMatchException.class, () ->
+                bookingService.checkBooking(code, differentDateEntry, roomNo)
         );
     }
 
@@ -593,8 +593,8 @@ class BookingServiceImplTest {
         // 예약 시간 15분 전 입실 시도
         LocalDateTime earlyEntry = date.minusMinutes(15);
 
-        assertThrows(BookingTimeNotReachedException.class, () ->
-                bookingService.checkBooking(no, code, earlyEntry, roomNo)
+        Assertions.assertThrows(BookingTimeNotReachedException.class, () ->
+                bookingService.checkBooking(code, earlyEntry, roomNo)
         );
     }
 
@@ -628,8 +628,8 @@ class BookingServiceImplTest {
         // 예약 시간 15분 이후 입실 시도
         LocalDateTime lateEntry = date.plusMinutes(15);
 
-        assertThrows(BookingTimeHasPassedException.class, () ->
-                bookingService.checkBooking(no, code, lateEntry, roomNo)
+        Assertions.assertThrows(BookingTimeHasPassedException.class, () ->
+                bookingService.checkBooking(code, lateEntry, roomNo)
         );
     }
 


### PR DESCRIPTION
## 📄 필독

- Front에서 meeting room service를 통해 전달받은 예약코드를 저장된 예약 내역의 예약코드와 비교하여 검증하는 로직
- 사용자 로그인을 통해 인증/인가를 거친 후 회의실 예약내역 조회 및 입실이 가능해야하나 인증/인가 기능 구현 미완성으로 테스트 계정과 고정된 날짜인 "2025-05-11"로 기능을 구현 및 연결함

---

## 📌 관련 이슈

* Resolves Pangyo-Coffee-Legends/backlog#111

---

## 📝 작업 내용

* Front-end에서 회의실을 선택하여 들어간 후, 현재 날짜로 예약되어 있는 예약 내역을 조회하고, 입실 버튼 클릭을 통해 입력한 예약코드를 검증하여 boolean을 반환
* 입력한 예약코드가 저장된 예약내역의 예약코드와 일치한다면 true 반환
* 예약코드는 일치하지만 입실시간이 아닌 경우, 예외 발생
* 그 외의 경우, 예외 발생

---

## ✅ 변경 사항 요약

| 항목       | 변경 전                      | 변경 후                                |
|------------|-------------------------------|-----------------------------------------|


---

## ✅ 체크리스트

* [x] 관련 이슈 번호를 `Fixes`, `Closes`, `Resolves` 중 하나로 정확히 적었는가?
* [x] 기능/버그/요청사항과 연관된 작업이 맞는가?
* [x] 코드에 문법 오류는 없는가?
* [x] 기능이 정상 동작하는가?

---

## 💡 리뷰어 참고 사항

* 추후, 사용자의 인증/인가 (로그인) 기능이 모두 구현된 후, 로그인한 사용자만 기능을 사용할 수 있도록 리팩토링 할 예정

---

## 📦 테스트 방법

1. 위에 언급한 바와 같이 테스트 계정(test@test.com)과 샘플 데이터를 저장해둔 h2 database 내 예약내역을 기준으로 '2025-05-11' 고정 날짜로 테스트 진행
2. 샘플 데이터에 저장된 예약코드로 입실 확인 진행
